### PR TITLE
Ice physics

### DIFF
--- a/globals/patch/ice/ice.c
+++ b/globals/patch/ice/ice.c
@@ -1,0 +1,128 @@
+#include "common.h"
+
+#define ACCELERATION 0.07f
+#define FRICTION_ICE 0.98f
+#define FRICTION     0.75f
+#define MAX_VELOCITY gPlayerStatus.runSpeed
+#define SPIN_SPEED   2.0f
+
+f32 _xv    = 0.0f;
+f32 _zv    = 0.0f;
+u8 _on_ice = FALSE;
+
+s32 test_ray_colliders(u32 ignore_flags, f32 start_x, f32 start_y, f32 start_z, f32 dir_x, f32 dir_y, f32 dir_z, f32* hit_x, f32* hit_y, f32* hit_z, f32* hit_depth, f32* hit_nx, f32* hit_ny, f32* hit_nz);
+s32 get_collider_type_by_id(s32 id);
+s32 do_lateral_collision(s32 type, PlayerStatus* player_status, f32* x, f32* y, f32* z, f32 depth, f32 yaw);
+s32 test_player_lateral(PlayerStatus* player, f32* x, f32* y, f32* z, f32 distance, f32 yaw);
+
+void input_to_move_vector(f32* angle, f32* speed);
+
+void sin_cos_deg(f32 theta, f32* sin, f32* cos);
+f32 get_clamped_angle_diff(f32 a, f32 b);
+
+s8 _clamp(s8 value, s8 min, s8 max, s8 deadzone) {
+	if (value > 0 && value < deadzone) return 0;
+	if (value < 0 && value > -deadzone) return 0;
+
+	if (value < min) return min;
+	if (value > max) return max;
+
+	return value;
+}
+
+f32 _abs(f32 value) {
+	return value > 0 ? value : -value;
+}
+
+void _apply_input(u8 no_interpolate) {
+	f32 heading, magnitude;
+	f32 target_xv, target_zv;
+
+	input_to_move_vector(&heading, &magnitude);
+	magnitude /= 70.0f;
+
+	sin_cos_deg(heading, &target_xv, &target_zv);
+	target_xv *= magnitude * MAX_VELOCITY;
+	target_zv *= magnitude * MAX_VELOCITY * -1;
+
+	if (magnitude) {
+		if (no_interpolate) {
+			_xv = target_xv;
+			_zv = target_zv;
+		} else {
+			_xv += (target_xv - _xv) * ACCELERATION;
+			_zv += (target_zv - _zv) * ACCELERATION;
+		}
+	} else {
+		_xv *= FRICTION_ICE;
+		if (_abs(_xv) < 0.01f) _xv = 0;
+
+		_zv *= FRICTION_ICE;
+		if (_abs(_zv) < 0.01f) _zv = 0;
+	}
+
+	if (_xv > MAX_VELOCITY) _xv *= 0.9f;
+	if (_xv < -MAX_VELOCITY) _xv *= 0.9f;
+
+	if (_zv > MAX_VELOCITY) _zv *= 0.9f;
+	if (_zv < -MAX_VELOCITY) _zv *= 0.9f;
+}
+
+u8 ice_physics_test(void) {
+	CollisionStatus gCollisionStatus = *(CollisionStatus*)0x8015A550;
+	s16 collider = gCollisionStatus.currentFloor;
+
+	if (collider == -1) return _on_ice;
+
+	return get_collider_type_by_id(collider) & 0x00000010; // new 'is ice' flag
+}
+
+void ice_physics_main(void) {
+	f32 xv, zv;
+	u32 gPlayerInputFlags = *(u32*)0x8010EFC8;
+
+	if (gPlayerInputFlags & 0x00002000) {
+		_xv = 0.0f;
+		_zv = 0.0f;
+		return;
+	}
+
+	if (_abs(_xv) < 0.03f) _xv = 0;
+	if (_abs(_zv) < 0.03f) _zv = 0;
+
+	if (ice_physics_test()) {
+		// On ice.
+
+		if (
+			!_on_ice || // First frame
+			gPlayerStatus.actionState == ActionState_IDLE ||
+			gPlayerStatus.actionState == ActionState_WALK ||
+			gPlayerStatus.actionState == ActionState_RUN
+		) {
+			// On first frame of ice, accelerate to full speed immediately. This makes walking onto ice not kill your velocity.
+			_apply_input(!_on_ice);
+		}
+
+		_on_ice = TRUE;
+	} else {
+		// We left ice, deccelerate quickly.
+
+		_xv *= FRICTION;
+		_zv *= FRICTION;
+
+		_on_ice = FALSE;
+	}
+
+	if (test_player_lateral(
+		&gPlayerStatus,
+		&gPlayerStatus.position.x, &gPlayerStatus.position.y, &gPlayerStatus.position.z,
+		dist2D(0.0f, 0.0f, _xv, _zv) * (gPlayerStatus.actionState == ActionState_SPIN ? SPIN_SPEED : 1.0f),
+		atan2(0.0f, 0.0f, _xv, _zv)
+	) == -1) {
+		// Movement done
+	} else {
+		// Hit a wall
+		_xv *= FRICTION;
+		_zv *= FRICTION;
+	}
+}

--- a/globals/patch/ice/ice.patch
+++ b/globals/patch/ice/ice.patch
@@ -1,0 +1,338 @@
+#new:Data $_xv { 0 }
+#new:Data $_zv { 0 }
+#new:Data $_on_ice { 0 }
+#new:Function $_clamp {
+	COPY      T1, A0
+	SLL       A0, A0, 24`
+	SRA       A0, A0, 24`
+	BLEZ      A0, .L2
+	COPY      T0, A3
+	SLL       V0, A3, 24`
+	SRA       V0, V0, 24`
+	SLT       V0, A0, V0
+	BNE       V0, R0, .L7
+	NOP
+	.L2
+	SLL       V0, T1, 24`
+	SRA       V1, V0, 24`
+	BGEZ      V1, .L9
+	SRA       A0, V0, 24`
+	SLL       V0, T0, 24`
+	SRA       V0, V0, 24`
+	SUBU      V0, R0, V0
+	SLT       V0, V0, V1
+	BEQ       V0, R0, .L3
+	SLL       V0, T1, 24`
+	.L7
+	JR        RA
+	COPY      V0, R0
+	.L3
+	SRA       A0, V0, 24`
+	.L9
+	SLL       V0, A1, 24`
+	SRA       V1, V0, 24`
+	SLT       V0, A0, V1
+	BEQ       V0, R0, .L4
+	SLL       V0, A2, 24`
+	JR        RA
+	COPY      V0, V1
+	.L4
+	SRA       V0, V0, 24`
+	SLT       V1, V0, A0
+	BEQL      V1, R0, .L8
+	COPY      V0, A0
+	.L8
+	JR        RA
+	NOP
+}
+#new:Function $_abs {
+	MTC1      R0, F0
+	C.LT.S    F0, F12
+	BC1FL     .L11
+	NEG.S     F12, F12
+	.L11
+	JR        RA
+	MOV.S     F0, F12
+}
+#new:Function $_apply_input {
+	ADDIU     SP, SP, -64`
+	SW        S0, 20 (SP)
+	COPY      S0, A0
+	ADDIU     A1, SP, 20`
+	SW        RA, 24 (SP)
+	SDC1      F24, 38 (SP)
+	SDC1      F22, 30 (SP)
+	SDC1      F20, 28 (SP)
+	JAL       ~Func:input_to_move_vector
+	ADDIU     A0, SP, 16`
+	ADDIU     A1, SP, 24`
+	ADDIU     A2, SP, 28`
+	LWC1      F0, 14 (SP)
+	LIF       F2, 70.000000
+	LWC1      F12, 10 (SP)
+	DIV.S     F0, F0, F2
+	JAL       ~Func:sin_cos_deg
+	SWC1      F0, 14 (SP)
+	LWC1      F4, 14 (SP)
+	LAF       F0, 8010F024
+	MUL.S     F0, F4, F0
+	NOP
+	LWC1      F2, 18 (SP)
+	MUL.S     F8, F2, F0
+	NOP
+	LWC1      F2, 1C (SP)
+	NEG.S     F0, F0
+	MUL.S     F0, F2, F0
+	NOP
+	MTC1      R0, F20
+	C.EQ.S    F4, F20
+	SWC1      F8, 18 (SP)
+	BC1T      .L13
+	SWC1      F0, 1C (SP)
+	ANDI      V0, S0, FF
+	BEQ       V0, R0, .L14
+	NOP
+	SAF       F8, $_xv
+	SAF       F0, $_zv
+	BEQ       R0, R0, .L16
+	NOP
+	.L14
+	LAF       F6, $_xv
+	SUB.S     F4, F8, F6
+	LIF       F8, 0.070000
+	MUL.S     F4, F4, F8
+	NOP
+	LAF       F2, $_zv
+	SUB.S     F0, F0, F2
+	MUL.S     F0, F0, F8
+	NOP
+	ADD.S     F6, F6, F4
+	ADD.S     F2, F2, F0
+	SAF       F6, $_xv
+	SAF       F2, $_zv
+	BEQ       R0, R0, .L16
+	NOP
+	.L13
+	LAF       F12, $_xv
+	LIF       F22, 0.980000
+	MUL.S     F12, F12, F22
+	NOP
+	LIF       F24, 0.010000
+	SAF       F12, $_xv
+	JAL       $_abs
+	NOP
+	C.LT.S    F0, F24
+	BC1F      .L17
+	NOP
+	SAF       F20, $_xv
+	.L17
+	LAF       F12, $_zv
+	MUL.S     F12, F12, F22
+	NOP
+	SAF       F12, $_zv
+	JAL       $_abs
+	NOP
+	C.LT.S    F0, F24
+	BC1F      .L16
+	NOP
+	SAF       F20, $_zv
+	.L16
+	LAF       F2, $_xv
+	LAF       F4, 8010F024
+	C.LT.S    F4, F2
+	BC1F      .L23
+	NEG.S     F6, F4
+	LIF       F0, 0.900000
+	MUL.S     F0, F2, F0
+	NOP
+	SAF       F0, $_xv
+	LAF       F2, $_xv
+	.L23
+	C.LT.S    F2, F6
+	BC1F      .L20
+	NOP
+	LIF       F0, 0.900000
+	MUL.S     F0, F2, F0
+	NOP
+	SAF       F0, $_xv
+	.L20
+	LAF       F2, $_zv
+	C.LT.S    F4, F2
+	BC1F      .L24
+	NOP
+	LIF       F0, 0.900000
+	MUL.S     F0, F2, F0
+	NOP
+	SAF       F0, $_zv
+	LAF       F2, $_zv
+	.L24
+	C.LT.S    F2, F6
+	BC1F      .L22
+	NOP
+	LIF       F0, 0.900000
+	MUL.S     F0, F2, F0
+	NOP
+	SAF       F0, $_zv
+	.L22
+	LW        RA, 24 (SP)
+	LW        S0, 20 (SP)
+	LDC1      F24, 38 (SP)
+	LDC1      F22, 30 (SP)
+	LDC1      F20, 28 (SP)
+	JR        RA
+	ADDIU     SP, SP, 64`
+}
+#new:Function $ice_physics_test {
+	ADDIU     SP, SP, -64`
+	SW        RA, 38 (SP)
+	ADDIU     V1, SP, 16`
+	LIO       V0, -7FEB0000
+	ORI       V0, V0, A550
+	LIO       A0, -7FEB0000
+	ORI       A0, A0, A570
+	.L26
+	LW        A1, 0 (V0)
+	LW        A2, 4 (V0)
+	LW        A3, 8 (V0)
+	LW        T0, C (V0)
+	SW        A1, 0 (V1)
+	SW        A2, 4 (V1)
+	SW        A3, 8 (V1)
+	SW        T0, C (V1)
+	ADDIU     V0, V0, 16`
+	BNE       V0, A0, .L26
+	ADDIU     V1, V1, 16`
+	LW        A1, 0 (V0)
+	LW        A2, 4 (V0)
+	SW        A1, 0 (V1)
+	SW        A2, 4 (V1)
+	LH        A0, 12 (SP)
+	LIO       V0, -1
+	BEQ       A0, V0, .L27
+	NOP
+	JAL       ~Func:get_collider_type_by_id
+	NOP
+	BEQ       R0, R0, .L28
+	ANDI      V0, V0, 10
+	.L27
+	LAB       V0, $_on_ice
+	.L28
+	LW        RA, 38 (SP)
+	JR        RA
+	ADDIU     SP, SP, 64`
+}
+#export $ice_physics_test
+#new:Function $ice_physics_main {
+	LAW       V0, -7FEF1038
+	ADDIU     SP, SP, -48`
+	SW        RA, 1C (SP)
+	SW        S0, 18 (SP)
+	SDC1      F22, 28 (SP)
+	SDC1      F20, 20 (SP)
+	ANDI      V0, V0, 2000
+	BEQ       V0, R0, .L30
+	NOP
+	SAW       R0, $_xv
+	SAW       R0, $_zv
+	BEQ       R0, R0, .L29
+	NOP
+	.L30
+	LAF       F12, $_xv
+	LIF       F20, 0.030000
+	JAL       $_abs
+	NOP
+	C.LT.S    F0, F20
+	BC1F      .L31
+	NOP
+	SAW       R0, $_xv
+	.L31
+	LAF       F12, $_zv
+	JAL       $_abs
+	NOP
+	C.LT.S    F0, F20
+	BC1F      .L32
+	NOP
+	SAW       R0, $_zv
+	.L32
+	JAL       $ice_physics_test
+	NOP
+	ANDI      V0, V0, FF
+	BEQ       V0, R0, .L33
+	NOP
+	LAB       V0, $_on_ice
+	BEQ       V0, R0, .L35
+	NOP
+	LAB       V1, 8010F07C
+	BEQ       V1, R0, .L35
+	ORI       V0, R0, 1
+	BEQ       V1, V0, .L35
+	ORI       V0, R0, 2
+	BNE       V1, V0, .L40
+	ORI       V0, R0, 1
+	.L35
+	LAB       A0, $_on_ice
+	JAL       $_apply_input
+	SLTIU     A0, A0, 1`
+	ORI       V0, R0, 1
+	.L40
+	SAB       V0, $_on_ice
+	BEQ       R0, R0, .L36
+	NOP
+	.L33
+	LAF       F0, $_xv
+	LIF       F4, 0.750000
+	MUL.S     F0, F0, F4
+	NOP
+	LAF       F2, $_zv
+	MUL.S     F2, F2, F4
+	NOP
+	SAB       R0, $_on_ice
+	SAF       F0, $_xv
+	SAF       F2, $_zv
+	.L36
+	LAW       A2, $_xv
+	MTC1      R0, F22
+	LAW       A3, $_zv
+	MOV.S     F12, F22
+	JAL       ~Func:dist2D
+	MOV.S     F14, F22
+	LIA       S0, 8010F07C
+	LB        V1, 0 (S0)
+	ORI       V0, R0, 1A
+	BNE       V1, V0, .L38
+	MOV.S     F20, F0
+	ADD.S     F20, F20, F20
+	.L38
+	MOV.S     F12, F22
+	LAW       A2, $_xv
+	LAW       A3, $_zv
+	JAL       ~Func:atan2
+	MOV.S     F14, F12
+	ADDIU     A0, S0, -180`
+	ADDIU     A2, S0, -136`
+	ADDIU     A3, S0, -132`
+	ADDIU     A1, S0, -140`
+	SWC1      F20, 10 (SP)
+	JAL       ~Func:test_player_lateral
+	SWC1      F0, 14 (SP)
+	LIO       V1, -1
+	BEQ       V0, V1, .L29
+	NOP
+	LAF       F0, $_xv
+	LIF       F4, 0.750000
+	MUL.S     F0, F0, F4
+	NOP
+	LAF       F2, $_zv
+	MUL.S     F2, F2, F4
+	NOP
+	SAF       F0, $_xv
+	SAF       F2, $_zv
+	.L29
+	LW        RA, 1C (SP)
+	LW        S0, 18 (SP)
+	LDC1      F22, 28 (SP)
+	LDC1      F20, 20 (SP)
+	JR        RA
+	ADDIU     SP, SP, 48`
+}
+#export $ice_physics_main

--- a/globals/patch/ice/ice_wrap.patch
+++ b/globals/patch/ice/ice_wrap.patch
@@ -1,0 +1,31 @@
+% RAM: 800E41F4 (collision_main_lateral)
+% Updates player position after applying input.
+% Changed to not write if on ice.
+@Hook 7D6A4 {
+	LWC1 F0, 20 (SP)
+	LWC1 F2, 28 (SP)
+
+	PUSH F0, F2
+		JAL $ice_physics_test
+		NOP
+	POP F0, F2
+	BNE V0, R0, .skip_update
+	NOP
+		% not on ice
+		J    800E4228 % set z
+		SWC1 F0, 28 (S1) % set x
+	.skip_update
+	J 800E422C
+	NOP
+}
+
+% RAM: 800E4300 (collision_main_lateral)
+% Hooks the JR RA.
+@Hook 7D7B0 {
+	ADDIU SP, SP, 80
+
+	PUSH RA
+		JAL $ice_physics_main
+		NOP
+	JPOP RA
+}


### PR DESCRIPTION
This branch adds a global patch implementing ice physics. Floor colliders with the `0x00000010` flag set will have slippery player movement. Thanks to Rain and Clover for assistance. Video below:

[![Video](https://user-images.githubusercontent.com/9429556/91613982-88482c00-e978-11ea-945b-2fcdba75f5dc.png)](https://www.youtube.com/watch?v=TiwwhFH-QkA)

---

To merge:

```
$ git merge upstream/ice
$ git submodule update --init --recursive
$ make -C star-rod-c setup
```

This patch branches from #1 as it is written in C. However, Star Rod C and a working compilation environment are not strictly required as this branch includes the compiled `ice.patch`. If you don't intend to write any C code or modify `ice.c` from this branch, you can cherry-pick the relevant commit to avoid merging in the `star-rod-c` submodule.

```
$ git cherry-pick 421339bff1df787df96e8773ab35fd09f685af21
```

<a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons Licence" align="left" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/4.0/88x31.png" /></a>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>. Credit must be included in mods released that use this patch. If you choose to release the source code of a mod using this patch, please include a link to this page.